### PR TITLE
Fix a few typos in the documentation

### DIFF
--- a/docs/src/explanation/transforms.md
+++ b/docs/src/explanation/transforms.md
@@ -161,7 +161,7 @@ defaults to `0, 1`.
 
 ## Scaling of line thickness
 
-Line thicknesses are not scaled by default. For example, with a current line thickness set by `setline(1)`, lines drawn before and after `scale(2)` will be the same thickness. If you want line thicknesses to respond to the current scale, so that a line thickness of 1 is scaled by `n` after calls to `scale(n)`, you can call `[setstrokescale`](@ref) with `true` to enable stroke scaling, and `setstrokescale(false)` to disable it. You can also enable stroke scaling when creating a new `Drawing` by passing the named argument `strokescale` during `Drawing` construction (i.e., `Drawing(400, 400, strokescale=true)`).
+Line thicknesses are not scaled by default. For example, with a current line thickness set by `setline(1)`, lines drawn before and after `scale(2)` will be the same thickness. If you want line thicknesses to respond to the current scale, so that a line thickness of 1 is scaled by `n` after calls to `scale(n)`, you can call [`setstrokescale`](@ref) with `true` to enable stroke scaling, and `setstrokescale(false)` to disable it. You can also enable stroke scaling when creating a new `Drawing` by passing the named argument `strokescale` during `Drawing` construction (i.e., `Drawing(400, 400, strokescale=true)`).
 
 ## Matrices
 

--- a/docs/src/howto/simplegraphics.md
+++ b/docs/src/howto/simplegraphics.md
@@ -639,7 +639,7 @@ You can draw lines, arcs, and curves with arrows at the end with [`arrow`](@ref)
 | Bezier 4 points                |arrow(pt1, pt2, pt3, pt4, action) |
 | Bezier start finish + box      |arrow(pt1, pt2, [ht1, ht2])       |
 
-For straight arrows, supply the start and end points. For arrows as circular arcs, you provide center, radius, and start and finish angles. You can optionally provide dimensions for the `arrowheadlength` and `arrowheadangle` of the tip of the arrow (angle in radians between side and center). The default line weight is 1.0, equivalent to `setline(1)`), but you can specify another.
+For straight arrows, supply the start and end points. For arrows as circular arcs, you provide center, radius, and start and finish angles. You can optionally provide dimensions for the `arrowheadlength` and `arrowheadangle` of the tip of the arrow (angle in radians between side and center). The default line weight is 1.0, equivalent to `setline(1)`, but you can specify another.
 
 ```@example
 using Luxor # hide

--- a/docs/src/tutorial/basictutorial.md
+++ b/docs/src/tutorial/basictutorial.md
@@ -79,7 +79,7 @@ This example illustrates a few things about Luxor drawings:
 
 - The text was placed at the origin point (0/0), and by default it's left aligned.
 
-- The circle wasn't filled, but [`stroked`. We passed the `:stroke` symbol as an action to the [`circle`](@ref) function. Many drawing functions expect some action, such as `:fill` or `:stroke`, and sometimes `:clip` or `:fillstroke`.
+- The circle wasn't filled, but `stroked`. We passed the `:stroke` symbol as an action to the [`circle`](@ref) function. Many drawing functions expect some action, such as `:fill` or `:stroke`, and sometimes `:clip` or `:fillstroke`.
 
 - Did the first drawing takes a few seconds to appear? The Cairo drawing engine takes a little time to warm up. Once it's running, drawings appear much faster.
 


### PR DESCRIPTION
Thanks for the awesome library! I found a few small typos while learning to use the package 😄 